### PR TITLE
Pushgateway notification aware of cluster node id

### DIFF
--- a/nifi-prometheus-reporting-task/src/main/java/org/apache/nifi/reporting/prometheus/api/PrometheusMetricsFactory.java
+++ b/nifi-prometheus-reporting-task/src/main/java/org/apache/nifi/reporting/prometheus/api/PrometheusMetricsFactory.java
@@ -18,83 +18,86 @@ public class PrometheusMetricsFactory {
     private static final Gauge AMOUNT_FLOWFILES_TOTAL = Gauge.build()
             .name("process_group_amount_flowfiles_total")
             .help("Total number of FlowFiles in ProcessGroup")
-            .labelNames("status", "server", "application", "process_group")
+            .labelNames("status", "application", "process_group")
             .register(NIFI_REGISTRY);
 
     private static final Gauge AMOUNT_BYTES_TOTAL = Gauge.build()
             .name("process_group_amount_bytes_total")
             .help("Total number of Bytes in ProcessGroup")
-            .labelNames("status", "server", "application", "process_group")
+            .labelNames("status", "application", "process_group")
             .register(NIFI_REGISTRY);
 
     private static final Gauge AMOUNT_THREADS_TOTAL = Gauge.build()
             .name("process_group_amount_threads_total")
             .help("Total amount of threads in ProcessGroup")
-            .labelNames("status", "server", "application", "process_group")
+            .labelNames("status", "application", "process_group")
             .register(NIFI_REGISTRY);
 
     private static final Gauge SIZE_CONTENT_TOTAL = Gauge.build()
             .name("process_group_size_content_total")
             .help("Total size of content in ProcessGroup")
-            .labelNames("status", "server", "application", "process_group")
+            .labelNames("status", "application", "process_group")
             .register(NIFI_REGISTRY);
 
     private static final Gauge AMOUNT_ITEMS = Gauge.build()
             .name("process_group_amount_items")
             .help("Total amount of items in ProcessGroup")
-            .labelNames("status", "server", "application", "process_group")
+            .labelNames("status", "application", "process_group")
             .register(NIFI_REGISTRY);
+
     private static final Gauge JVM_HEAP = Gauge.build()
             .name("jvm_heap_stats")
             .help("The JVM heap stats")
-            .labelNames("status", "server")
+            .labelNames("status")
             .register(JVM_REGISTRY);
+
     private static final Gauge JVM_THREAD = Gauge.build()
             .name("jvm_thread_stats")
             .help("The JVM thread stats")
-            .labelNames("status", "server")
+            .labelNames("status")
             .register(JVM_REGISTRY);
+
     private static final Gauge JVM_STATUS = Gauge.build()
             .name("jvm_general_stats")
             .help("The JVM general stats")
-            .labelNames("status", "server")
+            .labelNames("status")
             .register(JVM_REGISTRY);
 
-    public static CollectorRegistry createNifiMetrics(ProcessGroupStatus status, String hostname, String applicationId) {
+    public static CollectorRegistry createNifiMetrics(ProcessGroupStatus status, String applicationId) {
         String processGroupName = status.getName();
-        AMOUNT_FLOWFILES_TOTAL.labels("sent", hostname, applicationId, processGroupName).set(status.getFlowFilesSent());
-        AMOUNT_FLOWFILES_TOTAL.labels("transferred", hostname, applicationId, processGroupName).set(status.getFlowFilesTransferred());
-        AMOUNT_FLOWFILES_TOTAL.labels("received", hostname, applicationId, processGroupName).set(status.getFlowFilesReceived());
+        AMOUNT_FLOWFILES_TOTAL.labels("sent", applicationId, processGroupName).set(status.getFlowFilesSent());
+        AMOUNT_FLOWFILES_TOTAL.labels("transferred", applicationId, processGroupName).set(status.getFlowFilesTransferred());
+        AMOUNT_FLOWFILES_TOTAL.labels("received", applicationId, processGroupName).set(status.getFlowFilesReceived());
 
-        AMOUNT_BYTES_TOTAL.labels("sent", hostname, applicationId, processGroupName).set(status.getBytesSent());
-        AMOUNT_BYTES_TOTAL.labels("read", hostname, applicationId, processGroupName).set(status.getBytesRead());
-        AMOUNT_BYTES_TOTAL.labels("written", hostname, applicationId, processGroupName).set(status.getBytesWritten());
-        AMOUNT_BYTES_TOTAL.labels("received", hostname, applicationId, processGroupName).set(status.getBytesReceived());
-        AMOUNT_BYTES_TOTAL.labels("transferred", hostname, applicationId, processGroupName).set(status.getBytesTransferred());
+        AMOUNT_BYTES_TOTAL.labels("sent", applicationId, processGroupName).set(status.getBytesSent());
+        AMOUNT_BYTES_TOTAL.labels("read", applicationId, processGroupName).set(status.getBytesRead());
+        AMOUNT_BYTES_TOTAL.labels("written", applicationId, processGroupName).set(status.getBytesWritten());
+        AMOUNT_BYTES_TOTAL.labels("received", applicationId, processGroupName).set(status.getBytesReceived());
+        AMOUNT_BYTES_TOTAL.labels("transferred", applicationId, processGroupName).set(status.getBytesTransferred());
 
-        SIZE_CONTENT_TOTAL.labels("output", hostname, applicationId, processGroupName).set(status.getOutputContentSize());
-        SIZE_CONTENT_TOTAL.labels("input", hostname, applicationId, processGroupName).set(status.getInputContentSize());
-        SIZE_CONTENT_TOTAL.labels("queued", hostname, applicationId, processGroupName).set(status.getQueuedContentSize());
+        SIZE_CONTENT_TOTAL.labels("output", applicationId, processGroupName).set(status.getOutputContentSize());
+        SIZE_CONTENT_TOTAL.labels("input", applicationId, processGroupName).set(status.getInputContentSize());
+        SIZE_CONTENT_TOTAL.labels("queued", applicationId, processGroupName).set(status.getQueuedContentSize());
 
-        AMOUNT_ITEMS.labels("output", hostname, applicationId, processGroupName).set(status.getOutputCount());
-        AMOUNT_ITEMS.labels("input", hostname, applicationId, processGroupName).set(status.getInputCount());
-        AMOUNT_ITEMS.labels("queued", hostname, applicationId, processGroupName).set(status.getQueuedCount());
+        AMOUNT_ITEMS.labels("output", applicationId, processGroupName).set(status.getOutputCount());
+        AMOUNT_ITEMS.labels("input", applicationId, processGroupName).set(status.getInputCount());
+        AMOUNT_ITEMS.labels("queued", applicationId, processGroupName).set(status.getQueuedCount());
 
-        AMOUNT_THREADS_TOTAL.labels("nano", hostname, applicationId, processGroupName).set(status.getActiveThreadCount());
+        AMOUNT_THREADS_TOTAL.labels("nano", applicationId, processGroupName).set(status.getActiveThreadCount());
 
         return NIFI_REGISTRY;
     }
 
-    public static CollectorRegistry createJvmMetrics(VirtualMachineMetrics jvmMetrics, String hostname) {
-        JVM_HEAP.labels("used", hostname).set(jvmMetrics.heapUsed());
-        JVM_HEAP.labels("usage", hostname).set(jvmMetrics.heapUsage());
-        JVM_HEAP.labels("non_usage", hostname).set(jvmMetrics.nonHeapUsage());
+    public static CollectorRegistry createJvmMetrics(VirtualMachineMetrics jvmMetrics) {
+        JVM_HEAP.labels("used").set(jvmMetrics.heapUsed());
+        JVM_HEAP.labels("usage").set(jvmMetrics.heapUsage());
+        JVM_HEAP.labels("non_usage").set(jvmMetrics.nonHeapUsage());
 
-        JVM_THREAD.labels("count", hostname).set(jvmMetrics.threadCount());
-        JVM_THREAD.labels("daemon_count", hostname).set(jvmMetrics.daemonThreadCount());
+        JVM_THREAD.labels("count").set(jvmMetrics.threadCount());
+        JVM_THREAD.labels("daemon_count").set(jvmMetrics.daemonThreadCount());
 
-        JVM_STATUS.labels("count", hostname).set(jvmMetrics.uptime());
-        JVM_STATUS.labels("file_descriptor", hostname).set(jvmMetrics.fileDescriptorUsage());
+        JVM_STATUS.labels("count").set(jvmMetrics.uptime());
+        JVM_STATUS.labels("file_descriptor").set(jvmMetrics.fileDescriptorUsage());
 
         //TODO: implement jvm metrics for GC and thread stats (see old metrics service)
 

--- a/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusReportingTask.java
+++ b/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusReportingTask.java
@@ -117,7 +117,7 @@ public class TestPrometheusReportingTask {
                 .thenReturn(new MockPropertyValue(metricsUrl));
         Mockito.when(context.getProperty(PrometheusReportingTask.APPLICATION_ID))
                 .thenReturn(new MockPropertyValue(applicationId));
-        Mockito.when(context.getProperty(PrometheusReportingTask.HOSTNAME))
+        Mockito.when(context.getProperty(PrometheusReportingTask.INSTANCE_ID))
                 .thenReturn(new MockPropertyValue(hostName));
         Mockito.when(context.getProperty(PrometheusReportingTask.PROCESS_GROUP_IDS))
                 .thenReturn(new MockPropertyValue("1234"));


### PR DESCRIPTION
Current implementation does not allows to push metrics from multiple cluster nodes to the same pushgateway instance or rather allows but each nifi instance overrides data sent by others. This patch fixes this issue by using instance grouping key as it is recommended in pushgateway documentation.
  